### PR TITLE
Fix instance not defined error

### DIFF
--- a/__test__/rake.test.js
+++ b/__test__/rake.test.js
@@ -6,4 +6,16 @@ describe('rake', () => {
     expect(rake).toBeTruthy()
   })
 
+  describe('generate', () => {
+
+    it('extracts keywords from text', () => {
+
+      let text = "LDA stands for Latent Dirichlet Allocation. As already mentioned it is one of the more popular topic models which was initially proposed by Blei, Ng and Jordan in 2003. It is a generative model which, according to Wikipedia, allows sets of observations to be explained by unobserved groups that explain why some parts of the data are similar."
+
+      let results = rake.generate(text)
+      expect(results.length).toEqual(18)
+    })
+
+  })
+
 })

--- a/app.js
+++ b/app.js
@@ -2,11 +2,9 @@ var Rake = require('./index.js')
 var path = require("path");
 var stopwords_path = path.resolve(__dirname+'/'+'stopWords.txt')
 
-
-
 module.exports = {
   generate: function(content){
-    instance = new Rake(content,stopwords_path)
+    let instance = new Rake(content,stopwords_path)
     return instance.generate()
   }
 }


### PR DESCRIPTION
Added a test for the generate function revealed an error:

```javascript
ReferenceError: instance is not defined

      at Object.generate (app.js:9:14)
```

This appears to be caused by an accidental global.