### PR TITLE
Trim leading/trailing spaces from phrases

### DIFF
--- a/__test__/rake.test.js
+++ b/__test__/rake.test.js
@@ -8,12 +8,16 @@ describe('rake', () => {
 
   describe('generate', () => {
 
+    let text = "LDA stands for Latent Dirichlet Allocation. As already mentioned it is one of the more popular topic models which was initially proposed by Blei, Ng and Jordan in 2003. It is a generative model which, according to Wikipedia, allows sets of observations to be explained by unobserved groups that explain why some parts of the data are similar."
+
     it('extracts keywords from text', () => {
-
-      let text = "LDA stands for Latent Dirichlet Allocation. As already mentioned it is one of the more popular topic models which was initially proposed by Blei, Ng and Jordan in 2003. It is a generative model which, according to Wikipedia, allows sets of observations to be explained by unobserved groups that explain why some parts of the data are similar."
-
       let results = rake.generate(text)
       expect(results.length).toEqual(18)
+    })
+
+    it('trims leading and trailing spaces from keywords', () => {
+      let [firstKeyword, ...rest] = rake.generate(text)
+      expect(firstKeyword).toEqual("Latent Dirichlet Allocation")
     })
 
   })

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ class Rake {
         for(var phrase in phrases) {
             var phr = phrases[phrase].replace(/['!"“”’#$%&()\*+,\-\.\/:;<=>?@\[\\\]\^_`{|}~']/g,'')
             if(phr != ' ' && phr != '') {
-                phrase_list.push(phr)
+                phrase_list.push(phr.trim())
             }
         }
       }


### PR DESCRIPTION
This looked like a minor change but it has a significant impact on the results returned:

Before:
```javascript
    [ ' popular topic models ',
      ' Latent Dirichlet Allocation',
      'LDA stands ',
      ' initially proposed ',
      ' Blei Ng ',
      ' generative model ',
      ' unobserved groups ',
      ' 2003',
      ' mentioned ',
      ' similar',
      ' sets ',
      ' observations ',
      ' explained ',
      ' Jordan ',
      ' explain ',
      ' parts ',
      ' data ',
      ' Wikipedia ' ]
```

After:
```javascript
    [ 'Latent Dirichlet Allocation',
      'popular topic models',
      'initially proposed',
      'Blei Ng',
      'generative model',
      'LDA stands',
      'unobserved groups',
      'Wikipedia',
      'mentioned',
      '2003',
      'sets',
      'observations',
      'explained',
      'Jordan',
      'explain',
      'parts',
      'data',
      'similar' ]
```

To my eye this is a little more inline with my expectations given the test text, but I don't actually have any knowledge of the underlying algorithm yet, so it's just as likely that this change has broken things.

If you feel this doesn't make sense based on your understanding of the algorithm let me know if there is a better approach. I'm happy to make changes.