### PR TITLE
Filter newlines out of phrase list

### DIFF
--- a/__test__/rake.test.js
+++ b/__test__/rake.test.js
@@ -20,6 +20,19 @@ describe('rake', () => {
       expect(firstKeyword).toEqual("Latent Dirichlet Allocation")
     })
 
+    it("doesn't fail on text containing new lines", () => {
+      let sketchyText = `
+
+      Beyond the debateable minima already implied by the entrenchment of
+      negative liberty, no further, more committal, theory of justice is constitutive of liberal
+      order: indeed this is clearer than the analogous claim that democracy is not
+      constitutive of liberal order.
+
+      `
+      let [firstKeyword, ...rest] = rake.generate(sketchyText)
+      expect(firstKeyword).toEqual("debateable minima")
+    })
+
   })
 
 })

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ class Rake {
         var phrases = this.removeStopWords(sentence_list[s]);
         for(var phrase in phrases) {
             var phr = phrases[phrase].replace(/['!"“”’#$%&()\*+,\-\.\/:;<=>?@\[\\\]\^_`{|}~']/g,'')
-            if(phr != ' ' && phr != '') {
+            if(phr != ' ' && phr != '' && !/\n/.test(phr)) {
                 phrase_list.push(phr.trim())
             }
         }


### PR DESCRIPTION
The generatePhrases function was checking for '' and ' ' but not '\n'.
Input text containing new lines would find their way into the phrase
list and then blow up in calculateKeywordScores when word_list.length
was called. The error was:

```javascript
TypeError: Cannot read property 'length' of null
```