### PR TITLE
allows to pass a different stopwords list through an opts object

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,10 +1,14 @@
-var Rake = require('./index.js')
-var path = require("path");
-var stopwords_path = path.resolve(__dirname+'/'+'stopWords.txt')
+const Rake = require('./index.js');
+const path = require('path');
+const fs = require('fs');
+const stopwords_path = path.resolve(__dirname+'/'+'stopWords.txt');
 
 module.exports = {
-  generate: function(content){
-    let instance = new Rake(content,stopwords_path)
-    return instance.generate()
+  generate: function(content, opts = {}) {
+    const fileData = fs.readFileSync(stopwords_path).toString().split('\n');
+    const stopwordsList = opts.stopwords || fileData;
+
+    const instance = new Rake(content, stopwordsList);
+    return instance.generate();
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,21 +1,14 @@
-var fs = require('fs');
-
 class Rake {
 
-  constructor(text,stop_words_path){
+  constructor(text, stopwordsList){
     this.text = text;
-    this.stop_words_path = stop_words_path
+    this.stopwords = stopwordsList;
     this.regex_expression = this.buildRegex()
-  }
-
-  getStopWordsFromFile() {
-    var stopwords = fs.readFileSync(this.stop_words_path).toString().split("\n");
-    return stopwords
   }
 
   buildRegex(){
     var reg = ''
-    var stopwords_list = this.getStopWordsFromFile();
+    var stopwords_list = this.stopwords;
     for(var i in stopwords_list){
       var stopword = stopwords_list[i];
       if(i!=stopwords_list.length-1){reg = reg + stopword + '|';}


### PR DESCRIPTION
As discussed in #8, I've implemented a simple way to allow passing a custom stopwords list, it's still using the stopwords from the file by default, if nothing is passed inside the `opts` object.

Example of usage: 

```js
const rake = require('rake');
const text = "LDA stands for Latent Dirichlet Allocation";
const opts = {stopwords: ['for', 'the', 'a', 'stands', 'test', 'man', 'woman']};

let keywords = rake.generate(text, opts);
console.log(keywords); 
// it'll print: [ 'Latent Dirichlet Allocation', 'LDA' ]                     
```
I've refactored small parts of code while I was doing that. 

Please, let me know what you think before I write tests and update the docs. 