### PR TITLE
Fix for "Cannot read property 'length' of null"

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,21 +41,23 @@ class Rake {
     const wordScore = {};
     phraseList.forEach((phrase) => {
       const wordList = phrase.match(/[,.!?;:/‘’“”]|\b[0-9a-z']+\b/gi);
-      const wordListDegree = wordList.length;
-      wordList.forEach((word) => {
-        if (wordFreq[word]) {
-          wordFreq[word] += 1;
-        }
-        else {
-          wordFreq[word] = 1;
-        }
-        if (wordDegree[word]) {
-          wordDegree[word] += wordListDegree;
-        }
-        else {
-          wordDegree[word] = wordListDegree;
-        }
-      });
+      if(wordList){
+        const wordListDegree = wordList.length;
+        wordList.forEach((word) => {
+          if (wordFreq[word]) {
+            wordFreq[word] += 1;
+          }
+          else {
+            wordFreq[word] = 1;
+          }
+          if (wordDegree[word]) {
+            wordDegree[word] += wordListDegree;
+          }
+          else {
+            wordDegree[word] = wordListDegree;
+          }
+        });
+      }
     });
 
     Object.values(wordFreq).forEach((freq) => { wordDegree[freq] += wordFreq[freq]; });


### PR DESCRIPTION
For phrases that contained characters like " some text . . ." , which caused the match in line 43 to return null, an error was getting generated when attempting to read the length of null in the line 70. This proposed fix does resolve the issue, but there may be a better way by modifying the regex above to keep "null" from getting returned.