### PR TITLE
Word bounaries for unicode chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ class Rake {
     phraseList.forEach((phrase) => {
       phraseScores[phrase] = 0;
       let candidateScore = 0;
-      const wordList = phrase.match(/(\b[^\s]+\b)/g);
+      const wordList = phrase.match(/([^\s]+)/g);
       wordList.forEach((word) => { candidateScore += wordScore[word]; });
       phraseScores[phrase] = candidateScore;
     });


### PR DESCRIPTION
\b are not working for languages other than english. Which makes it impossible to use at all. Simply removing them seems to work fine though.